### PR TITLE
bug fix (build): npm ssl Error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ WORKDIR /root/dataloader
 EXPOSE 3001
 RUN git clone --recursive https://github.com/camicroscope/ImageLoader.git .
 RUN git submodule update --recursive --remote
+RUN npm config set strict-ssl false
 RUN npm install
 
 RUN ["pip3","install", "-r",  "/root/dataloader/DataLoader/requirements.txt"]


### PR DESCRIPTION
Received error upon build.  
The cause is: npm no longer supports its self-signed certificates.
Fixed with: `npm set strict-ssl false`